### PR TITLE
Remove correlationId from experiment-03 SharedWorker RPC system

### DIFF
--- a/experiment-03/SUBSCRIPTION_TRACKING_ANALYSIS.md
+++ b/experiment-03/SUBSCRIPTION_TRACKING_ANALYSIS.md
@@ -1,0 +1,99 @@
+# Subscription Tracking Analysis
+
+## Problem: Redundant Client-Side Tracking
+
+The current implementation in experiment-03 has unnecessary duplication of subscription management between client and worker.
+
+## Current Architecture (experiment-03)
+
+### Client-side (`client.ts`)
+
+```typescript
+class WorkerProxy<T> {
+  private activeSubscriptions: Set<() => void> = new Set(); // ❌ Redundant
+
+  protected addSubscription(unsubscribe: () => void): void; // ❌ Manual tracking
+  protected removeSubscription(unsubscribe: () => void): void;
+
+  dispose(): void {
+    // Calls all tracked unsubscribe functions
+    for (const unsubscribe of this.activeSubscriptions) {
+      unsubscribe(); // ❌ Duplicates worker cleanup
+    }
+  }
+}
+```
+
+### Worker-side (`worker.ts`)
+
+```typescript
+interface ClientRep {
+  eachSubscription: Map<string, Subscription>; // ✅ Already tracking
+  allSubscriptions: Subscription; // ✅ Already handles cleanup
+}
+
+// ✅ Automatic cleanup via Web Locks API
+navigator.locks.request(clientId, async () => {
+  client.allSubscriptions.unsubscribe();
+  client.eachSubscription.clear();
+  this.clients.delete(clientId);
+});
+```
+
+## Cleaner Architecture (experiment-02)
+
+### Client-side (`client.ts`)
+
+```typescript
+abstract class WorkerProxy<T> {
+  protected proxy: Comlink.Remote<T>;
+  // ✅ No subscription tracking - worker handles it
+  // ✅ No dispose() method - Web Locks handle cleanup
+}
+```
+
+### Worker-side (`worker.ts`)
+
+```typescript
+// ✅ Same as experiment-03 - single source of truth for subscriptions
+// ✅ Web Locks API automatically cleans up when client disconnects
+```
+
+## Why Client Tracking is Unnecessary
+
+1. **Worker Already Manages Everything**
+   - `ClientRep` tracks all subscriptions per client
+   - Web Locks API automatically triggers cleanup when client disconnects
+   - RxJS composite subscription handles bulk unsubscription
+
+2. **Double Cleanup Problem**
+   - Client `dispose()` calls worker unsubscribe functions
+   - Worker also cleans up the same subscriptions via Web Locks
+   - Creates race conditions and redundant work
+
+3. **Manual Burden**
+   - Subclasses must remember to call `addSubscription()`
+   - Easy to forget, leading to memory leaks
+   - Adds complexity with no benefit
+
+4. **Comlink Handles Proxy Cleanup**
+   - Only real client-side cleanup needed is `proxy[Comlink.releaseProxy]()`
+   - Everything else should be delegated to the worker
+
+## Recommended Approach
+
+**Client is just a proxy** - let the worker handle subscription lifecycle:
+
+```typescript
+// ✅ Simple client - no subscription tracking
+abstract class WorkerProxy<T> {
+  protected proxy: Comlink.Remote<T>;
+
+  // Worker handles all subscription cleanup via Web Locks
+  // Client only needs to release Comlink proxy if desired
+}
+```
+
+## Conclusion
+
+The **experiment-02 approach is correct**. Client-side subscription tracking in experiment-03 is redundant overhead that duplicates what the worker already handles efficiently via Web Locks API.

--- a/experiment-03/src/shared-worker/core/client.ts
+++ b/experiment-03/src/shared-worker/core/client.ts
@@ -8,28 +8,21 @@ export interface CreateClientOptions<TContract> {
   worker: SharedWorker;
   Client: ClientConstructor<TContract>;
   generateClientId?: () => string;
-  generateCorrelationId?: () => string;
 }
 
 export type ClientConstructor<TContract> = new (
   port: MessagePort,
-  clientId: string,
-  getCorrelationId: () => string,
+  clientId: string
 ) => TContract;
 
 export abstract class WorkerProxy<T> {
   protected proxy: Comlink.Remote<T>;
   protected clientId: string;
-  protected getCorrelationId: () => string;
+  private activeSubscriptions: Set<() => void> = new Set();
 
-  constructor(
-    port: MessagePort,
-    clientId: string,
-    getCorrelationId: () => string,
-  ) {
+  constructor(port: MessagePort, clientId: string) {
     this.proxy = Comlink.wrap<T>(port);
     this.clientId = clientId;
-    this.getCorrelationId = getCorrelationId;
   }
 
   getClientId(): string {
@@ -44,12 +37,8 @@ class RegistryClient
   private isRegistered = false;
   private registration: PromiseWithResolvers<void> | undefined;
 
-  constructor(
-    port: MessagePort,
-    clientId: string,
-    getCorrelationId: () => string = () => crypto.randomUUID(),
-  ) {
-    super(port, clientId, getCorrelationId);
+  constructor(port: MessagePort, clientId: string) {
+    super(port, clientId);
   }
 
   async registerClient(): Promise<void> {
@@ -65,7 +54,7 @@ class RegistryClient
     this.registration = registration;
 
     navigator.locks.request(this.clientId, async () => {
-      await this.proxy.registerClient(this.clientId, crypto.randomUUID());
+      await this.proxy.registerClient(this.clientId);
       this.isRegistered = true;
       registration.resolve();
       return new Promise(() => {});
@@ -76,21 +65,16 @@ class RegistryClient
 }
 
 export const createClient = async <T>(
-  options: CreateClientOptions<T>,
+  options: CreateClientOptions<T>
 ): Promise<T> => {
   const {
     worker,
     Client,
     generateClientId = () => crypto.randomUUID(),
-    generateCorrelationId = () => crypto.randomUUID(),
   } = options;
 
   const clientId = generateClientId();
-  const registryClient = new RegistryClient(
-    worker.port,
-    clientId,
-    generateCorrelationId,
-  );
+  const registryClient = new RegistryClient(worker.port, clientId);
   await registryClient.registerClient();
-  return new Client(worker.port, clientId, generateCorrelationId);
+  return new Client(worker.port, clientId);
 };

--- a/experiment-03/src/shared-worker/core/client.ts
+++ b/experiment-03/src/shared-worker/core/client.ts
@@ -18,7 +18,6 @@ export type ClientConstructor<TContract> = new (
 export abstract class WorkerProxy<T> {
   protected proxy: Comlink.Remote<T>;
   protected clientId: string;
-  private activeSubscriptions: Set<() => void> = new Set();
 
   constructor(port: MessagePort, clientId: string) {
     this.proxy = Comlink.wrap<T>(port);

--- a/experiment-03/src/shared-worker/core/types.ts
+++ b/experiment-03/src/shared-worker/core/types.ts
@@ -10,20 +10,12 @@ type ArgsToParams<Args> = Args extends void
 
 export type Query<Args = void, Response = void> = {
   client: (...args: ArgsToParams<Args>) => Promise<Response>;
-  worker: (
-    clientId: string,
-    correlationId: string,
-    ...args: ArgsToParams<Args>
-  ) => Promise<Response>;
+  worker: (clientId: string, ...args: ArgsToParams<Args>) => Promise<Response>;
 };
 
 export type Mutation<Args = void, Result = void> = {
   client: (...args: ArgsToParams<Args>) => Promise<Result>;
-  worker: (
-    clientId: string,
-    correlationId: string,
-    ...args: ArgsToParams<Args>
-  ) => Promise<Result>;
+  worker: (clientId: string, ...args: ArgsToParams<Args>) => Promise<Result>;
 };
 
 export type Subscription<Args = void, Update = void> = {
@@ -32,7 +24,6 @@ export type Subscription<Args = void, Update = void> = {
   ) => Promise<() => void>;
   worker: (
     clientId: string,
-    correlationId: string,
     ...args: [...ArgsToParams<Args>, callback: (value: Update) => void]
   ) => Promise<() => void>;
 };

--- a/experiment-03/src/shared-worker/core/worker.ts
+++ b/experiment-03/src/shared-worker/core/worker.ts
@@ -3,22 +3,20 @@ import { Observable, Subscription } from "rxjs";
 
 interface ClientRep {
   clientId: string;
-  eachSubscription: Map<string, Subscription>;
-  allSubscriptions: Subscription;
+  subscriptions: Subscription;
 }
 
 const createClientRep = (clientId: string): ClientRep => ({
   clientId,
-  eachSubscription: new Map(),
-  allSubscriptions: new Subscription(),
+  subscriptions: new Subscription(),
 });
 
 export abstract class BaseWorker {
   protected clients: Map<string, ClientRep> = new Map();
 
-  async registerClient(clientId: string, correlationId: string): Promise<void> {
+  async registerClient(clientId: string): Promise<void> {
     if (this.clients.has(clientId)) return;
-    console.log("registerClient", clientId, correlationId);
+    console.log("registerClient", clientId);
     this.clients.set(clientId, createClientRep(clientId));
 
     navigator.locks.request(clientId, async () => {
@@ -28,30 +26,27 @@ export abstract class BaseWorker {
         console.warn(`Attempted to unregister unknown client: ${clientId}`);
         return;
       }
-      client.allSubscriptions.unsubscribe();
-      client.eachSubscription.clear();
+      client.subscriptions.unsubscribe();
       this.clients.delete(clientId);
     });
   }
 
   protected async subscribe<T>(
     clientId: string,
-    correlationId: string,
     callback: (value: T) => void,
     source$: Observable<T>,
   ): Promise<() => void> {
     const client = this.getClient(clientId);
-    const subscription = source$.subscribe(callback);
-    client.eachSubscription.set(correlationId, subscription);
-    client.allSubscriptions.add(subscription);
+    const subscription = source$.subscribe((value) => {
+      console.log("emit", clientId, value);
+      callback(value);
+    });
+    client.subscriptions.add(subscription);
 
     return Comlink.proxy(() => {
-      const subscription = client.eachSubscription.get(correlationId);
-      if (!subscription) return;
-      console.log("unsubscribe", clientId, correlationId);
+      console.log("unsubscribe", clientId);
       subscription.unsubscribe();
-      client.allSubscriptions.remove(subscription);
-      client.eachSubscription.delete(correlationId);
+      client.subscriptions.remove(subscription);
     });
   }
 

--- a/experiment-03/src/shared-worker/core/worker.ts
+++ b/experiment-03/src/shared-worker/core/worker.ts
@@ -37,10 +37,7 @@ export abstract class BaseWorker {
     source$: Observable<T>,
   ): Promise<() => void> {
     const client = this.getClient(clientId);
-    const subscription = source$.subscribe((value) => {
-      console.log("emit", clientId, value);
-      callback(value);
-    });
+    const subscription = source$.subscribe(callback);
     client.subscriptions.add(subscription);
 
     return Comlink.proxy(() => {

--- a/experiment-03/src/shared-worker/echo/client.ts
+++ b/experiment-03/src/shared-worker/echo/client.ts
@@ -6,16 +6,12 @@ export class EchoClient
   extends WorkerProxy<EchoWorkerContract>
   implements EchoClientContract
 {
-  constructor(
-    port: MessagePort,
-    clientId: string,
-    getCorrelationId: () => string,
-  ) {
-    super(port, clientId, getCorrelationId);
+  constructor(port: MessagePort, clientId: string) {
+    super(port, clientId);
   }
 
   echo(message: string): Promise<string> {
-    return this.proxy.echo(this.clientId, this.getCorrelationId(), message);
+    return this.proxy.echo(this.clientId, message);
   }
 
   async subscribeEcho(
@@ -23,7 +19,6 @@ export class EchoClient
   ): Promise<() => void> {
     return this.proxy.subscribeEcho(
       this.clientId,
-      this.getCorrelationId(),
       Comlink.proxy(callback),
     );
   }

--- a/experiment-03/src/shared-worker/echo/index.ts
+++ b/experiment-03/src/shared-worker/echo/index.ts
@@ -10,10 +10,10 @@ export const createEchoClient = memoize(
         {
           type: "module",
           name,
-        }
+        },
       ),
       Client: EchoClient,
-    })
+    }),
 );
 
 export const getEchoClientOne = () => createEchoClient("Echo One");

--- a/experiment-03/src/shared-worker/echo/worker.ts
+++ b/experiment-03/src/shared-worker/echo/worker.ts
@@ -5,23 +5,18 @@ import type { EchoWorkerContract } from "./contract";
 export class EchoWorker extends BaseWorker implements EchoWorkerContract {
   private echo$ = new Subject<string>();
 
-  async echo(
-    clientId: string,
-    correlationId: string,
-    message: string,
-  ): Promise<string> {
+  async echo(clientId: string, message: string): Promise<string> {
     const echoedMessage = `echo: ${message}`;
-    console.log("echo", clientId, correlationId, echoedMessage);
+    console.log("echo", clientId, echoedMessage);
     this.echo$.next(echoedMessage);
     return echoedMessage;
   }
 
   subscribeEcho(
     clientId: string,
-    correlationId: string,
     callback: (message: string) => void,
   ): Promise<() => void> {
-    console.log("subscribeEcho", clientId, correlationId);
-    return this.subscribe(clientId, correlationId, callback, this.echo$);
+    console.log("subscribeEcho", clientId);
+    return this.subscribe(clientId, callback, this.echo$);
   }
 }


### PR DESCRIPTION
## Summary
- Remove correlationId parameter from Query, Mutation, and Subscription worker method signatures
- Simplify client constructor and proxy creation by eliminating correlation ID generation and tracking