### PR TITLE
Add experiment-05: JS Proxy with additional arguments

### DIFF
--- a/experiment-05/README.md
+++ b/experiment-05/README.md
@@ -1,0 +1,22 @@
+# experiment-05: JS Proxy: Pass additional arguments with Proxy traps
+
+## Overview
+
+Demonstrates how to use JavaScript Proxy to intercept function calls and add additional arguments before passing them to the target object.
+
+## Implementation
+
+This experiment shows how to:
+
+- Create a target object with a `multiplyByTwo` function that takes a number and returns it multiplied by 2
+- Use a Proxy with a `get` trap to intercept property access
+- When the accessed property is a function, return a wrapper that accepts an additional string argument
+- Log the string argument and then call the original function with the remaining arguments
+- Return non-function properties unchanged
+
+## Usage
+
+1. Start the dev server: `npm run dev`
+2. Navigate to: <http://localhost:5173/experiment-05/>
+3. Click the buttons to see how the proxy intercepts function calls vs direct calls
+4. Check the browser console to see the logged messages from the proxy

--- a/experiment-05/index.html
+++ b/experiment-05/index.html
@@ -1,0 +1,14 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>
+      experiment-05: JS Proxy: Pass additional arguments with Proxy traps
+    </title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="./src/main.tsx"></script>
+  </body>
+</html>

--- a/experiment-05/src/App.tsx
+++ b/experiment-05/src/App.tsx
@@ -1,0 +1,44 @@
+import { target, proxy } from "./proxy";
+
+function App() {
+  const handleDirectCall = () => {
+    const result = target.multiplyByTwo(5);
+    console.log("Direct call result:", result);
+  };
+
+  const handleProxyCall = () => {
+    const result = proxy.multiplyByTwo("Calling multiplyByTwo via proxy!", 5);
+    console.log("Proxy call result:", result);
+  };
+
+  const handlePropertyAccess = () => {
+    console.log("Direct property access:", target.someProperty);
+    console.log("Proxy property access:", proxy.someProperty);
+  };
+
+  return (
+    <section>
+      <h1>
+        {"experiment-05"}:{" "}
+        {"JS Proxy: Pass additional arguments with Proxy traps"}
+      </h1>
+      <div style={{ marginTop: "20px" }}>
+        <button onClick={handleDirectCall} style={{ margin: "5px" }}>
+          Call target.multiplyByTwo(5) directly
+        </button>
+        <button onClick={handleProxyCall} style={{ margin: "5px" }}>
+          Call proxy.multiplyByTwo('message', 5)
+        </button>
+        <button onClick={handlePropertyAccess} style={{ margin: "5px" }}>
+          Access someProperty via both
+        </button>
+      </div>
+      <p style={{ marginTop: "20px" }}>
+        Check the console to see the proxy intercepting function calls and
+        logging the message argument.
+      </p>
+    </section>
+  );
+}
+
+export default App;

--- a/experiment-05/src/index.css
+++ b/experiment-05/src/index.css
@@ -1,0 +1,73 @@
+:root {
+  font-family: system-ui, Avenir, Helvetica, Arial, sans-serif;
+  line-height: 1.5;
+  font-weight: 400;
+  font-synthesis: none;
+  text-rendering: optimizeLegibility;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+/* https://www.joshwcomeau.com/css/custom-css-reset/ */
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+* {
+  margin: 0;
+}
+
+@media (prefers-reduced-motion: no-preference) {
+  html {
+    interpolate-size: allow-keywords;
+  }
+}
+
+img,
+picture,
+video,
+canvas,
+svg {
+  display: block;
+  max-width: 100%;
+}
+
+input,
+button,
+textarea,
+select {
+  font: inherit;
+}
+
+p,
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+  overflow-wrap: break-word;
+}
+
+p {
+  text-wrap: pretty;
+}
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+  text-wrap: balance;
+}
+
+#root,
+#__next {
+  isolation: isolate;
+}
+
+section {
+  padding: 1rem;
+}

--- a/experiment-05/src/main.tsx
+++ b/experiment-05/src/main.tsx
@@ -1,0 +1,10 @@
+import { StrictMode } from "react";
+import { createRoot } from "react-dom/client";
+import "./index.css";
+import App from "./App.tsx";
+
+createRoot(document.getElementById("root")!).render(
+  <StrictMode>
+    <App />
+  </StrictMode>,
+);

--- a/experiment-05/src/proxy.ts
+++ b/experiment-05/src/proxy.ts
@@ -1,0 +1,45 @@
+interface Target {
+  multiplyByTwo: (num: number) => number;
+  someProperty: string;
+}
+
+interface ProxiedTarget {
+  multiplyByTwo: (message: string, num: number) => number;
+  someProperty: string;
+}
+
+const target: Target = {
+  multiplyByTwo: (num: number) => num * 2,
+  someProperty: "hello world",
+};
+
+const proxy = new Proxy(target, {
+  get(target, prop, receiver) {
+    const value = Reflect.get(target, prop, receiver);
+
+    if (typeof value === "function") {
+      return function (message: string, ...args: unknown[]) {
+        console.log(message);
+        return value.apply(target, args);
+      };
+    }
+
+    return value;
+  },
+}) as unknown as ProxiedTarget;
+
+// Demo usage
+console.log("=== Direct target calls ===");
+console.log("target.multiplyByTwo(5):", target.multiplyByTwo(5));
+console.log("target.someProperty:", target.someProperty);
+
+console.log("\n=== Proxy calls ===");
+console.log(
+  "proxy.multiplyByTwo('Hello from proxy!', 5):",
+  proxy.multiplyByTwo("Hello from proxy!", 5)
+);
+console.log(
+  "proxy.multiplyByTwo('Another message', 10):",
+  proxy.multiplyByTwo("Another message", 10)
+);
+console.log("proxy.someProperty:", proxy.someProperty);


### PR DESCRIPTION
## Summary
- Add experiment-05 demonstrating JavaScript Proxy usage for intercepting function calls
- Implements a target object with multiplyByTwo function and proxy that adds string logging parameter
- Shows how to pass additional arguments through proxy traps while preserving original function behavior