### PR TITLE
Update experiment-05: Reverse proxy pattern with automatic ID injection

### DIFF
--- a/experiment-05/README.md
+++ b/experiment-05/README.md
@@ -2,21 +2,35 @@
 
 ## Overview
 
-Demonstrates how to use JavaScript Proxy to intercept function calls and add additional arguments before passing them to the target object.
+Demonstrates how to use JavaScript Proxy to automatically inject additional arguments when calling internal API methods, creating a clean public interface that hides implementation details.
 
 ## Implementation
 
 This experiment shows how to:
 
-- Create a target object with a `multiplyByTwo` function that takes a number and returns it multiplied by 2
-- Use a Proxy with a `get` trap to intercept property access
-- When the accessed property is a function, return a wrapper that accepts an additional string argument
-- Log the string argument and then call the original function with the remaining arguments
-- Return non-function properties unchanged
+- Create an **Internal API** (`InternalApi`) that requires a `proxyId` parameter for tracking/logging
+- Create a **Public API** (`PublicApi`) that provides a clean interface without the tracking parameter
+- Use a Proxy with a `get` trap to automatically inject the `proxyId` when functions are called
+- Generate unique proxy IDs for each proxy instance to enable tracking and debugging
+
+The flow works like this:
+
+```
+Public API: proxy.multiplyByTwo(5)
+    ↓ (proxy automatically injects proxyId)
+Internal API: target.multiplyByTwo("proxy-abc123", 5)
+```
+
+## Key Features
+
+- **Automatic ID injection**: The proxy transparently adds a unique identifier to all function calls
+- **Clean public interface**: Users of the public API don't need to know about internal tracking requirements
+- **Type safety**: Full TypeScript support with proper interface definitions
+- **Non-function properties**: Properties are passed through unchanged
 
 ## Usage
 
 1. Start the dev server: `npm run dev`
 2. Navigate to: <http://localhost:5173/experiment-05/>
-3. Click the buttons to see how the proxy intercepts function calls vs direct calls
-4. Check the browser console to see the logged messages from the proxy
+3. Click the buttons to see how the proxy automatically injects proxy IDs
+4. Check the browser console to see the internal API receiving the injected proxy IDs

--- a/experiment-05/src/App.tsx
+++ b/experiment-05/src/App.tsx
@@ -2,13 +2,13 @@ import { target, proxy } from "./proxy";
 
 function App() {
   const handleDirectCall = () => {
-    const result = target.multiplyByTwo(5);
-    console.log("Direct call result:", result);
+    const result = target.multiplyByTwo("manual-id", 5);
+    console.log("Direct internal API call result:", result);
   };
 
   const handleProxyCall = () => {
-    const result = proxy.multiplyByTwo("Calling multiplyByTwo via proxy!", 5);
-    console.log("Proxy call result:", result);
+    const result = proxy.multiplyByTwo(5);
+    console.log("Public API (proxy) call result:", result);
   };
 
   const handlePropertyAccess = () => {
@@ -24,18 +24,18 @@ function App() {
       </h1>
       <div style={{ marginTop: "20px" }}>
         <button onClick={handleDirectCall} style={{ margin: "5px" }}>
-          Call target.multiplyByTwo(5) directly
+          Call target.multiplyByTwo('manual-id', 5) directly
         </button>
         <button onClick={handleProxyCall} style={{ margin: "5px" }}>
-          Call proxy.multiplyByTwo('message', 5)
+          Call proxy.multiplyByTwo(5) - proxy adds ID
         </button>
         <button onClick={handlePropertyAccess} style={{ margin: "5px" }}>
           Access someProperty via both
         </button>
       </div>
       <p style={{ marginTop: "20px" }}>
-        Check the console to see the proxy intercepting function calls and
-        logging the message argument.
+        Check the console to see how the proxy automatically injects the proxy
+        ID when calling the internal API.
       </p>
     </section>
   );

--- a/experiment-05/src/proxy.ts
+++ b/experiment-05/src/proxy.ts
@@ -1,45 +1,52 @@
-interface Target {
+interface WorkerApi {
+  multiplyByTwo: (clientId: string, num: number) => number;
+  someProperty: string;
+}
+
+interface ClientApi {
   multiplyByTwo: (num: number) => number;
   someProperty: string;
 }
 
-interface ProxiedTarget {
-  multiplyByTwo: (message: string, num: number) => number;
-  someProperty: string;
-}
-
-const target: Target = {
-  multiplyByTwo: (num: number) => num * 2,
+const target: WorkerApi = {
+  multiplyByTwo: (clientId: string, num: number) => {
+    console.log(`Internal API called with proxyId: ${clientId}`);
+    return num * 2;
+  },
   someProperty: "hello world",
 };
 
-const proxy = new Proxy(target, {
-  get(target, prop, receiver) {
-    const value = Reflect.get(target, prop, receiver);
+function createClient(target: WorkerApi): ClientApi {
+  const clientId = crypto.randomUUID();
+  console.log(`Created client with ID: ${clientId}`);
 
-    if (typeof value === "function") {
-      return function (message: string, ...args: unknown[]) {
-        console.log(message);
-        return value.apply(target, args);
-      };
-    }
+  return new Proxy(target, {
+    get(target, prop, receiver) {
+      const value = Reflect.get(target, prop, receiver);
 
-    return value;
-  },
-}) as unknown as ProxiedTarget;
+      if (typeof value === "function") {
+        return function (...args: unknown[]) {
+          // Inject proxyId as first argument
+          return value.apply(target, [clientId, ...args]);
+        };
+      }
+
+      return value;
+    },
+  }) as unknown as ClientApi;
+}
+
+const proxy = createClient(target);
 
 // Demo usage
-console.log("=== Direct target calls ===");
-console.log("target.multiplyByTwo(5):", target.multiplyByTwo(5));
+console.log("=== Direct internal API calls ===");
+console.log(
+  "target.multiplyByTwo('manual-id', 5):",
+  target.multiplyByTwo("manual-id", 5)
+);
 console.log("target.someProperty:", target.someProperty);
 
-console.log("\n=== Proxy calls ===");
-console.log(
-  "proxy.multiplyByTwo('Hello from proxy!', 5):",
-  proxy.multiplyByTwo("Hello from proxy!", 5)
-);
-console.log(
-  "proxy.multiplyByTwo('Another message', 10):",
-  proxy.multiplyByTwo("Another message", 10)
-);
+console.log("\n=== Public API calls (via proxy) ===");
+console.log("proxy.multiplyByTwo(5):", proxy.multiplyByTwo(5));
+console.log("proxy.multiplyByTwo(10):", proxy.multiplyByTwo(10));
 console.log("proxy.someProperty:", proxy.someProperty);


### PR DESCRIPTION
## Summary
- Reverse the proxy pattern: InternalApi requires proxyId parameter, PublicApi provides clean interface
- Add createProxy factory function that generates unique UUIDs for each proxy instance
- Proxy automatically injects crypto.randomUUID() as first argument when calling internal API methods
- Users get a clean public API while internal implementation receives tracking/logging IDs transparently